### PR TITLE
Windows CI : Update Scoop Install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tinyphone_win_job:
     name: Build Tinyphone Windows
-    runs-on: windows-2019
+    runs-on: windows-2016
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tinyphone_win_job:
     name: Build Tinyphone Windows
-    runs-on: windows-2016
+    runs-on: windows-2019
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,8 @@ jobs:
     - name: Install Scoop & Binaries
       run : |
         [Net.ServicePointManager]::SecurityProtocol =[Net.SecurityProtocolType]::Tls12 ; 
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh');
+        (New-Object System.Net.WebClient).DownloadFile('https://get.scoop.sh', "install_scoop.ps1");
+        .\install_scoop.ps1 -RunAsAdmin
         scoop install curl wget cmake unzip make;
 
     - name: Install wixtoolset

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
     .\install_scoop.ps1 -RunAsAdmin
 
     # Install Git & other tools
-    scoop install git wget cmake openssh unzip make sed cat
+    scoop install git wget cmake openssh unzip make sed 
 
 configuration: Release
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,8 @@ install:
     ls "C:\local\boost_1_68_0"
 
     # Install Scoop
-    iwr -useb get.scoop.sh | iex
+    iwr -useb get.scoop.sh -outfile 'install_scoop.ps1'
+    .\install_scoop.ps1 -RunAsAdmin
 
     # Install Git & other tools
     powershell.exe scoop install git wget cmake openssh unzip make sed cat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
     .\install_scoop.ps1 -RunAsAdmin
 
     # Install Git & other tools
-    powershell.exe scoop install git wget cmake openssh unzip make sed cat
+    scoop install git wget cmake openssh unzip make sed cat
 
 configuration: Release
 build_script:


### PR DESCRIPTION
```
[Net.ServicePointManager]::SecurityProtocol =[Net.SecurityProtocolType]::Tls12 ; 
  Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh/');
  scoop install curl wget cmake unzip make;
  shell: C:\Program Files\PowerShell\[7](https://github.com/voiceip/tinyphone/runs/5596610599?check_suite_focus=true#step:6:7)\pwsh.EXE -command ". '{0}'"
Initializing...
Running the installer as administrator is disabled by default, see https://github.com/ScoopInstaller/Install#for-admin for details.
Abort.
```