### PR TITLE
Implement `TinyPhone::Join`  (can be used to join two specific calls together)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ The softphone exposes the following resources on port `6060`.
 <td>Break specified <code>call_id</code> out of conference</td>
 </tr>
 <tr>
+<td><code>/calls/{call_id}/join/{call_to_join_id}</code></td>
+<td>POST</td>
+<td></td>
+<td>Merges the current call (<code>call_id</code>) with another running call (<code>call_to_join_id</code>)</td>
+</tr>
+<tr>
 <td><code>/calls/{call_id}/transfer</code></td>
 <td>POST</td>
 <td>

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ The softphone exposes the following resources on port `6060`.
 <td>Merges the current call (<code>call_id</code>) with another running call (<code>call_to_join_id</code>)</td>
 </tr>
 <tr>
+<td><code>/calls/{call_id}/unjoin/{call_to_unjoin_id}</code></td>
+<td>POST</td>
+<td></td>
+<td>Break specified <code>call_id</code> out of conference with <code>call_to_join_id</code></td>
+</tr>
+<tr>
 <td><code>/calls/{call_id}/transfer</code></td>
 <td>POST</td>
 <td>

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The softphone exposes the following resources on port `6060`.
 <td><code>/calls/{call_id}/unjoin/{call_to_unjoin_id}</code></td>
 <td>POST</td>
 <td></td>
-<td>Break specified <code>call_id</code> out of conference with <code>call_to_join_id</code></td>
+<td>Break specified <code>call_id</code> out of conference with <code>call_to_unjoin_id</code></td>
 </tr>
 <tr>
 <td><code>/calls/{call_id}/transfer</code></td>

--- a/tinyphone/phone.cpp
+++ b/tinyphone/phone.cpp
@@ -549,7 +549,6 @@ namespace tp {
 		}
 
 		try {
-			// start bidirectional audio
 			aud_med.startTransmit(aud_med2);
 			aud_med2.startTransmit(aud_med);
 		} catch(...) {
@@ -558,5 +557,33 @@ namespace tp {
 		}
 
 		return true;
+	}
+
+	bool TinyPhone::Unjoin(SIPCall* call, SIPCall* call_to_unjoin) {
+		try {
+			call_to_unjoin->HoldCall();   
+		} catch(...) {
+			PJ_LOG(3, (__FILENAME__, "TinyPhone::Unjoin HoldCall Error"));
+			return false;
+		}
+
+		AudioMedia aud_med, aud_med2;
+		try {
+			aud_med = call->getAudioMedia(-1);
+			aud_med2 = call_to_unjoin->getAudioMedia(-1);
+		} catch(...) {
+			PJ_LOG(3, (__FILENAME__, "TinyPhone::Unjoin getAudioMedia Error"));
+			return false;
+		}
+
+		try {
+			aud_med.stopTransmit(aud_med2);
+			aud_med2.stopTransmit(aud_med);
+		} catch(...) {
+			PJ_LOG(3, (__FILENAME__, "TinyPhone::Unjoin stopTransmit Error"));
+			return false;
+		}
+
+		return true;		
 	}
 }

--- a/tinyphone/phone.cpp
+++ b/tinyphone/phone.cpp
@@ -531,5 +531,32 @@ namespace tp {
 		return true;
 	}
 
-}
+	bool TinyPhone::Join(SIPCall* call, SIPCall* call_to_join) {
+		try {
+			call_to_join->UnHoldCall();   
+		} catch(...) {
+			PJ_LOG(3, (__FILENAME__, "TinyPhone::Join UnHoldCall Error"));
+			return false;
+		}
 
+		AudioMedia aud_med, aud_med2;
+		try {
+			aud_med = call->getAudioMedia(-1);
+			aud_med2 = call_to_join->getAudioMedia(-1);
+		} catch(...) {
+			PJ_LOG(3, (__FILENAME__, "TinyPhone::Join getAudioMedia Error"));
+			return false;
+		}
+
+		try {
+			// start bidirectional audio
+			aud_med.startTransmit(aud_med2);
+			aud_med2.startTransmit(aud_med);
+		} catch(...) {
+			PJ_LOG(3, (__FILENAME__, "TinyPhone::Join startTransmit Error"));
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/tinyphone/phone.h
+++ b/tinyphone/phone.h
@@ -122,6 +122,8 @@ namespace tp {
 
 		bool Conference(SIPCall* call);
 		bool BreakConference(SIPCall* call);
+		
+		bool Join(SIPCall* call, SIPCall* call_to_join);
 
 		void HangupAllCalls();
 

--- a/tinyphone/phone.h
+++ b/tinyphone/phone.h
@@ -124,6 +124,7 @@ namespace tp {
 		bool BreakConference(SIPCall* call);
 		
 		bool Join(SIPCall* call, SIPCall* call_to_join);
+		bool Unjoin(SIPCall* call, SIPCall* call_to_unjoin);
 
 		void HangupAllCalls();
 

--- a/tinyphone/server.cpp
+++ b/tinyphone/server.cpp
@@ -636,6 +636,50 @@ void TinyPhoneHttpServer::Start() {
 		}
 	});
 
+	CROW_ROUTE(app, "/calls/<int>/unjoin/<int>")
+		.methods("POST"_method)
+		([&phone](int call_id, int call_to_unjoin_id) {
+		pj_thread_auto_register();
+
+		SIPCall* call = phone.CallById(call_id);
+		SIPCall* call_to_unjoin = phone.CallById(call_to_unjoin_id);
+
+		if (call == nullptr) {
+			return tp::response(400, {
+				{ "message", "Current Call Not Found" },
+				{ "call_id" , call_id },
+				{ "call_to_unjoin_id" , call_to_unjoin_id },
+			});
+		}
+		else if (call_to_unjoin == nullptr) {
+			return tp::response(400, {
+				{ "message", "Call To Unjoin Not Found" },
+				{ "call_id" , call_id },
+				{ "call_to_unjoin_id" , call_to_unjoin_id }
+			});
+		}
+		else if (call->HoldState() == +HoldStatus::LOCAL_HOLD) {
+			json response = {
+				{ "message",  "Bad Request, CallOnHold Currently" },
+				{ "call_id" , call_id },
+				{ "call_to_unjoin_id" , call_to_unjoin_id },
+				{ "status", "400" }
+			};
+
+			return tp::response(400, response);
+		}
+		else {
+			json response = {
+				{ "message",  "Calls Unjoin Triggered" },
+				{ "call_id" , call_id },
+				{ "call_to_unjoin_id" , call_to_unjoin_id },
+				{ "response", phone.Unjoin(call, call_to_unjoin) }
+			};
+
+			return tp::response(200, response);
+		}
+	});
+
 	CROW_ROUTE(app, "/calls/<int>/transfer")
 	.methods("POST"_method)
 	([&phone](const crow::request& req, int call_id) {

--- a/tinyphone/server.cpp
+++ b/tinyphone/server.cpp
@@ -603,25 +603,32 @@ void TinyPhoneHttpServer::Start() {
 		if (call == nullptr) {
 			return tp::response(400, {
 				{ "message", "Current Call Not Found" },
-				{ "call_id" , call_id }
+				{ "call_id" , call_id },
+				{ "call_to_join_id" , call_to_join_id },
 			});
 		}
 		else if (call_to_join == nullptr) {
 			return tp::response(400, {
 				{ "message", "Call To Join Not Found" },
-				{ "call_id" , call_to_join_id }
+				{ "call_id" , call_id },
+				{ "call_to_join_id" , call_to_join_id }
 			});
 		}
 		else if (call->HoldState() == +HoldStatus::LOCAL_HOLD) {
-				response["message"] = "Bad Request, CallOnHold Currently";
-				response["status"] = "400";
-				return tp::response(400, response);
+			json response = {
+				{ "message",  "Bad Request, CallOnHold Currently" },
+				{ "call_id" , call_id },
+				{ "call_to_join_id" , call_to_join_id },
+				{ "status", "400" }
+			};
+
+			return tp::response(400, response);
 		}
 		else {
 			json response = {
 				{ "message",  "Calls Join Triggered" },
 				{ "call_id" , call_id },
-				{ "call_id_ToJoin" , call_to_join_id },
+				{ "call_to_join_id" , call_to_join_id },
 				{ "response", phone.Join(call, call_to_join) }
 			};
 


### PR DESCRIPTION
This PR implements `TinyPhone::Join` and the following endpoint: `/calls/<int>/join/<int>`

This method is very similar to `TinyPhone::Conference`. It can be used to initiate a conference between an active call and a second, specific call (as opposed to `TinyPhone::Conference`, which joins all ongoing calls together).