### PR TITLE
Github CI : Upgrade to  macos-13, Ubuntu 24.04

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       security-events: write
 
-    runs-on: macos-11
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +51,7 @@ jobs:
 
         #boost
         pushd tinyphone-osx/vendor/boost
-        ./boost.sh -macos --boost-version 1.74.0
+        ./boost.sh -macos --boost-version 1.84.0 --no-thinning
         popd
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,7 +56,7 @@ jobs:
         cat ./distribution/docker/release.ps1 | docker run -v ${PWD}:"C:\Code\tinyphone" -i  ghcr.io/${{ github.repository_owner }}/tinyphone_base:vc2019
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tinyphone_installer
         path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
   tinyphone_osx_job:
     name: Build Tinyphone macOS
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -105,8 +105,8 @@ jobs:
         KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
         # import certificate and provisioning profile from secrets
-        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-        #echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode --output $PP_PATH
+        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+        #echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
         # create temporary keychain
         security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
@@ -128,7 +128,7 @@ jobs:
       shell: bash
       run : |
         export HOMEBREW_NO_INSTALL_CLEANUP=true
-        brew install autoconf automake libtool tree wget opencore-amr
+        brew install autoconf automake libtool opencore-amr tree
         wget https://gist.githubusercontent.com/kingster/1954ead3c38a40cac88c5c1311bb39c5/raw/343da2c7a2a52ee5a1c03902cc5e44ed83b1dd5d/cryptopp.rb
         brew install --build-from-source -f cryptopp.rb 
         npm install -g appdmg
@@ -140,8 +140,11 @@ jobs:
 
         #boost
         pushd tinyphone-osx/vendor/boost
-        ./boost.sh -macos --boost-version 1.74.0
+        ./boost.sh -macos --boost-version 1.84.0 --no-thinning
         popd
+
+        # dump the content of the framework
+        # tree tinyphone-osx/vendor/boost/dist/boost.xcframework
 
         #stastd
         pushd lib/statsd-cpp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
   tinyphone_linux_job:
     name: Build Tinyphone Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -193,7 +193,7 @@ jobs:
       shell: bash
       run : |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libcurl4-openssl-dev pkg-config libboost1.71-all-dev libasound-dev
+        sudo apt-get install -y build-essential cmake libcurl4-openssl-dev pkg-config libboost1.83-all-dev libasound-dev
 
     - name: Compile Libraries
       run : |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
         .\distribution\docker\release.ps1 -ErrorAction Stop
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tinyphone.msi
         path: |
@@ -162,7 +162,7 @@ jobs:
         # codesign --force --sign "Apple Development" tinyphone.dmg 
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tinyphone.dmg
         path: |
@@ -230,7 +230,7 @@ jobs:
         make
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tinyphone.linux
         path: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	url = https://github.com/voiceip/statsd-cpp.git
 [submodule "tinyphone-osx/vendor/boost"]
 	path = tinyphone-osx/vendor/boost
-	url = https://github.com/faithfracture/Apple-Boost-BuildScript.git
+	url = https://github.com/mathieugarcia/Apple-Boost-BuildScript.git
 [submodule "lib/spdlog"]
 	path = lib/spdlog
 	url = https://github.com/gabime/spdlog.git

--- a/tinyphone-osx/Tinyphone.xcodeproj/project.pbxproj
+++ b/tinyphone-osx/Tinyphone.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		B3DDA55125515DF700D269C9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1110;
 				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = "Kinshuk  Bairagi";
@@ -630,7 +631,7 @@
 					/usr/local/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = "36.0.0.84";
+				MARKETING_VERSION = 36.0.0.85;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DBOOST_SYSTEM_DYN_LINK",
@@ -682,7 +683,7 @@
 					/usr/local/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = "36.0.0.84";
+				MARKETING_VERSION = 36.0.0.85;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DBOOST_SYSTEM_DYN_LINK",

--- a/tinyphone-osx/Tinyphone.xcodeproj/project.pbxproj
+++ b/tinyphone-osx/Tinyphone.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -24,6 +24,10 @@
 		B33839092551D3EF000D6F04 /* osxapp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B33839082551D3EF000D6F04 /* osxapp.cpp */; };
 		B36B645B27E30DB100B011C9 /* libopencore-amrnb.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B36B645927E30DB000B011C9 /* libopencore-amrnb.0.dylib */; };
 		B36B645C27E30DB100B011C9 /* libopencore-amrwb.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B36B645A27E30DB000B011C9 /* libopencore-amrwb.0.dylib */; };
+		B3742D522D5DB4AE00E0DFC8 /* libcrypto.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B3742D512D5DB4AE00E0DFC8 /* libcrypto.3.dylib */; };
+		B3742D542D5DB4D800E0DFC8 /* libssl.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B3742D532D5DB4D800E0DFC8 /* libssl.3.dylib */; };
+		B3742D552D5DB4E500E0DFC8 /* libssl.3.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B3742D532D5DB4D800E0DFC8 /* libssl.3.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		B3742D562D5DB4E500E0DFC8 /* libcrypto.3.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B3742D512D5DB4AE00E0DFC8 /* libcrypto.3.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B392C7B9255412560068492F /* libcryptopp.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B392C7B8255412560068492F /* libcryptopp.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B39C3B442552C3CE00BBD999 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = B39C3B432552C3CE00BBD999 /* libresolv.tbd */; };
 		B39C3B4B2552E1E700BBD999 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B39C3B4A2552E1E700BBD999 /* AppKit.framework */; };
@@ -31,7 +35,6 @@
 		B3AD62CB27E327C600F6A499 /* libopencore-amrnb.0.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B36B645927E30DB000B011C9 /* libopencore-amrnb.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B3AD62CC27E327C600F6A499 /* libopencore-amrwb.0.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B36B645A27E30DB000B011C9 /* libopencore-amrwb.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B3B92C3E2568152A0095EF2C /* mod_notify.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3B92C3D2568152A0095EF2C /* mod_notify.cpp */; };
-		B3C9365527E34ED300CE2CDB /* BuildFile in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B3D53FC92551696600523D5F /* AccountsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3D53FC82551696600523D5F /* AccountsView.xib */; };
 		B3D53FCC255169CF00523D5F /* AccountsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D53FCB255169CF00523D5F /* AccountsView.swift */; };
 		B3D53FCE25516A4200523D5F /* LoadableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D53FCD25516A4200523D5F /* LoadableView.swift */; };
@@ -50,7 +53,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B3C9365527E34ED300CE2CDB /* BuildFile in Embed Frameworks */,
+				B3742D552D5DB4E500E0DFC8 /* libssl.3.dylib in Embed Frameworks */,
+				B3742D562D5DB4E500E0DFC8 /* libcrypto.3.dylib in Embed Frameworks */,
 				B3AD62CB27E327C600F6A499 /* libopencore-amrnb.0.dylib in Embed Frameworks */,
 				B3AD62CC27E327C600F6A499 /* libopencore-amrwb.0.dylib in Embed Frameworks */,
 				B392C7B9255412560068492F /* libcryptopp.dylib in Embed Frameworks */,
@@ -103,6 +107,8 @@
 		B33839082551D3EF000D6F04 /* osxapp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = osxapp.cpp; sourceTree = "<group>"; };
 		B36B645927E30DB000B011C9 /* libopencore-amrnb.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libopencore-amrnb.0.dylib"; path = "/usr/local/opt/opencore-amr/lib/libopencore-amrnb.0.dylib"; sourceTree = "<absolute>"; };
 		B36B645A27E30DB000B011C9 /* libopencore-amrwb.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libopencore-amrwb.0.dylib"; path = "/usr/local/opt/opencore-amr/lib/libopencore-amrwb.0.dylib"; sourceTree = "<absolute>"; };
+		B3742D512D5DB4AE00E0DFC8 /* libcrypto.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcrypto.3.dylib; path = "/usr/local/opt/openssl@3/lib/libcrypto.3.dylib"; sourceTree = "<absolute>"; };
+		B3742D532D5DB4D800E0DFC8 /* libssl.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libssl.3.dylib; path = "/usr/local/opt/openssl@3/lib/libssl.3.dylib"; sourceTree = "<absolute>"; };
 		B392C7B8255412560068492F /* libcryptopp.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcryptopp.dylib; path = /usr/local/opt/cryptopp/lib/libcryptopp.dylib; sourceTree = "<absolute>"; };
 		B39C3B432552C3CE00BBD999 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 		B39C3B4A2552E1E700BBD999 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -137,6 +143,8 @@
 				B39C3B442552C3CE00BBD999 /* libresolv.tbd in Frameworks */,
 				B327CB542551A2FD0092FDB7 /* AudioToolbox.framework in Frameworks */,
 				B327CB522551A2F40092FDB7 /* AudioUnit.framework in Frameworks */,
+				B3742D542D5DB4D800E0DFC8 /* libssl.3.dylib in Frameworks */,
+				B3742D522D5DB4AE00E0DFC8 /* libcrypto.3.dylib in Frameworks */,
 				B3AD62C827E3174300F6A499 /* boost.xcframework in Frameworks */,
 				B327CB502551A2940092FDB7 /* CoreAudio.framework in Frameworks */,
 				B327CB032551973A0092FDB7 /* libstatsd_static.a in Frameworks */,
@@ -230,6 +238,8 @@
 		B3DDA55025515DF700D269C9 = {
 			isa = PBXGroup;
 			children = (
+				B3742D532D5DB4D800E0DFC8 /* libssl.3.dylib */,
+				B3742D512D5DB4AE00E0DFC8 /* libcrypto.3.dylib */,
 				B36B645927E30DB000B011C9 /* libopencore-amrnb.0.dylib */,
 				B36B645A27E30DB000B011C9 /* libopencore-amrwb.0.dylib */,
 				B337E2C32554468C001696B7 /* config.json */,
@@ -278,6 +288,7 @@
 				B327CB0825519E550092FDB7 /* Embed Frameworks */,
 				B392C7A52554035D0068492F /* Run Script */,
 				896443F6A4B218BA6302E72F /* [CP] Embed Pods Frameworks */,
+				B3AF374D2D5DDA47001AD835 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -393,7 +404,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nEXECFILE=${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}\ndeclare -a TARGETS=(\"libcryptopp.dylib\"  \"libopencore-amrnb.0.dylib\" \"libopencore-amrwb.0.dylib\") # \"libopus.0.dylib\"\nfor TARGET in \"${TARGETS[@]}\" ; do\necho \"Running for $TARGET\"\nFULLTARGET=`otool -LD ${EXECFILE} | grep $TARGET | awk '{ print $1 }'`\necho $FULLTARGET\ninstall_name_tool -change ${FULLTARGET} \"@rpath/${TARGET}\" ${EXECFILE}\ndone\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nEXECFILE=${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}\n\n\ndeclare -a TARGETS=(\"libcryptopp.dylib\"  \"libopencore-amrnb.0.dylib\" \"libopencore-amrwb.0.dylib\" \"libcrypto.3.dylib\" \"libssl.3.dylib\") # \"libopus.0.dylib\"\nfor TARGET in \"${TARGETS[@]}\" ; do\necho \"Running for $TARGET\"\nFULLTARGET=`otool -LD ${EXECFILE} | grep $TARGET | awk '{ print $1 }'`\necho $FULLTARGET\ninstall_name_tool -change ${FULLTARGET} \"@rpath/${TARGET}\" ${EXECFILE}\ndone\n\n\n\n";
+		};
+		B3AF374D2D5DDA47001AD835 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\n#patch libssl.3.dylib\necho \"Patching SSL Libraries\"\n\nEXECFILE=${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/libssl.3.dylib\n\ndeclare -a TARGETS=(\"libcrypto.3.dylib\") \nfor TARGET in \"${TARGETS[@]}\" ; do\necho \"Patching for $TARGET\"\nFULLTARGET=`otool -LD ${EXECFILE} | grep $TARGET | awk '{ print $1 }'`\necho $FULLTARGET\ninstall_name_tool -change ${FULLTARGET} \"@rpath/${TARGET}\" ${EXECFILE}\ndone\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tinyphone-osx/Tinyphone.xcodeproj/xcshareddata/xcschemes/Tinyphone.xcscheme
+++ b/tinyphone-osx/Tinyphone.xcodeproj/xcshareddata/xcschemes/Tinyphone.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1530"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/tinyphone-osx/src/Tinyphone-C-Interface.h
+++ b/tinyphone-osx/src/Tinyphone-C-Interface.h
@@ -19,6 +19,8 @@ const char* GetOSXProductVersion();
 
 const char* GetResourceFilePath(const char * name);
 
+const char* GetAppSupportFilePath(const char * name);
+
 const char* GetLogsDirectory();
 
 #endif /* Tinyphone_C_Interface_h */

--- a/tinyphone-osx/src/Tinyphone-OC.mm
+++ b/tinyphone-osx/src/Tinyphone-OC.mm
@@ -62,6 +62,13 @@ const char* GetOSXProductVersion(){
     return [myInstance GetProductVersion];
 }
 
+const char* GetAppSupportFilePath(const char * name){
+    NSString* file = @(name);
+    NSString* basePath = @(GetAppSupportDirectory());
+    NSString* finalPath = [basePath stringByAppendingPathComponent:file];
+    return [finalPath UTF8String];;
+}
+
 const char* GetResourceFilePath(const char * name){
     CFURLRef appUrlRef = CFBundleCopyResourceURL(CFBundleGetMainBundle(), CFSTR("config.json"), NULL, NULL);
     if (appUrlRef != nullptr){

--- a/tinyphone-osx/src/Tinyphone-OC.mm
+++ b/tinyphone-osx/src/Tinyphone-OC.mm
@@ -66,7 +66,7 @@ const char* GetAppSupportFilePath(const char * name){
     NSString* file = @(name);
     NSString* basePath = @(GetAppSupportDirectory());
     NSString* finalPath = [basePath stringByAppendingPathComponent:file];
-    return [finalPath UTF8String];;
+    return [finalPath UTF8String];
 }
 
 const char* GetResourceFilePath(const char * name){

--- a/tinyphone-osx/src/osxapp.cpp
+++ b/tinyphone-osx/src/osxapp.cpp
@@ -57,7 +57,7 @@ struct UIAccountInfoArray Accounts(){
                 acc.active = account->getInfo().regIsActive;
                 accounts.push_back(acc);
             }
-            arrInfo.count = accounts.size();
+            arrInfo.count = (int) accounts.size();
             if (accounts.size() < 10 ) {
                 std::copy(accounts.begin(), accounts.end(), arrInfo.accounts);
             }

--- a/tinyphone/baseapp.cpp
+++ b/tinyphone/baseapp.cpp
@@ -21,6 +21,15 @@
 using namespace std;
 using namespace pj;
 
+/**
+ * @file baseapp.cpp
+ * @brief Implementation of the base application functionality for TinyPhone.
+ * 
+ * This file contains the implementation of the base application functionality for TinyPhone.
+ * It includes functions for initializing the PJSUA endpoint, starting and stopping the application,
+ * and retrieving the phone object.
+ */
+
 #define MAX_DNS_SERVERS 4
 
 inline void  pj_logerror(pj_status_t status, char * message) {

--- a/tinyphone/config.cpp
+++ b/tinyphone/config.cpp
@@ -107,13 +107,16 @@ namespace tp {
 		}
 
 #ifdef ALLOW_OFFLINE_CONFIG
-        std::string local_file_path = LOCAL_CONFIG_FILE;
+		std::string local_file_path = LOCAL_CONFIG_FILE;
 #ifdef __APPLE__
-        auto apple_config_file = GetResourceFilePath(local_file_path.c_str());
-        if(apple_config_file != nullptr){
-            std::string lp(apple_config_file);
-            local_file_path.swap(lp);
-        }
+		auto apple_config_file = GetAppSupportFilePath(local_file_path.c_str());
+		
+		if (apple_config_file != nullptr) {
+			std::cout << "Checking if Local File Exists " << apple_config_file << std::endl;
+			std::string lp(apple_config_file);
+			local_file_path.swap(lp);
+		}
+		
 #endif
 		if(file_exists(local_file_path)){
 			jsonConfig = file_get_contents(local_file_path);

--- a/tinyphone/stampver.inf
+++ b/tinyphone/stampver.inf
@@ -1,5 +1,5 @@
 ;StampVer information file
-FileVersion=36.0.0.84
-ProductVersion=36.0.0.84
+FileVersion=36.0.0.85
+ProductVersion=36.0.0.85
 FileFormat=%a.%b.%c
 ProductFormat=%a.%b.%c

--- a/tinyphone/utils.h
+++ b/tinyphone/utils.h
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <thread>
 #include <vector>
+#include <fstream>
 #include <sstream>
 #include "consts.h"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Upgraded build pipelines and continuous integration workflows across Windows, macOS, Linux, and Docker for enhanced stability and dependency management.
  - Updated system configurations and product version from 36.0.0.84 to 36.0.0.85 for improved compatibility.
  - Updated submodule URL for Boost library.
  - Updated commit identifier for the Boost library subproject.

- **New Features**
  - Introduced enhanced file support on macOS, enabling more robust and dynamic file path management.
  - Added a new function for retrieving the application support file path based on a provided name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->