### PR TITLE
Set uaConfig.maxCalls

### DIFF
--- a/tinyphone/baseapp.cpp
+++ b/tinyphone/baseapp.cpp
@@ -82,6 +82,7 @@ namespace tp {
             ep_cfg.logConfig.decor |= PJ_LOG_HAS_CR | PJ_LOG_HAS_DAY_OF_MON |  PJ_LOG_HAS_MONTH |  PJ_LOG_HAS_YEAR ;
             ep_cfg.uaConfig.userAgent = ApplicationConfig.ua();
             ep_cfg.uaConfig.threadCnt = ApplicationConfig.pjThreadCount;
+            ep_cfg.uaConfig.maxCalls = ApplicationConfig.maxCalls;
             if (ApplicationConfig.enableSTUN) {
                 ep_cfg.uaConfig.stunServer = ApplicationConfig.stunServers;
             }


### PR DESCRIPTION
`config.json` contains a `maxCalls` variable. However, this variable was not passed to PJSIP, which meant that the maximum number of calls was limited to 4 (the default value) :

```c++
    // endpoint.hpp
    
    /**
     * Maximum calls to support (default: 4). The value specified here
     * must be smaller than the compile time maximum settings
     * PJSUA_MAX_CALLS, which by default is 32. To increase this
     * limit, the library must be recompiled with new PJSUA_MAX_CALLS
     * value.
     */
    unsigned        maxCalls;
```