### PR TITLE
Disable content-type validation on configuration

### DIFF
--- a/tinyphone/config.cpp
+++ b/tinyphone/config.cpp
@@ -70,6 +70,7 @@ namespace tp {
 		}
 
 		// Disable the content-type check. raw.githubusercontent.com doesn't return valid content-type
+		// Security Note: JSON parsing validation still occurs later to ensure content validity.
 		// if (remoteConfig.code / 100 != 2 ) || contentType.rfind("application/json", 0) != 0 ) {
 		if (remoteConfig.code / 100 != 2 ) {
 			//Try Secondary Location

--- a/tinyphone/config.cpp
+++ b/tinyphone/config.cpp
@@ -69,7 +69,9 @@ namespace tp {
 			contentType = contentTypeIt->second;
 		}
 
-		if (remoteConfig.code / 100 != 2 || contentType.rfind("application/json", 0) != 0 ) {
+		// Disable the content-type check. raw.githubusercontent.com doesn't return valid content-type
+		// if (remoteConfig.code / 100 != 2 ) || contentType.rfind("application/json", 0) != 0 ) {
+		if (remoteConfig.code / 100 != 2 ) {
 			//Try Secondary Location
 			message = "ERROR: Failed to fetch Remote Config from Primary!";
 			if (remoteConfig.error != "")


### PR DESCRIPTION
```
$ curl -i https://raw.githubusercontent.com/voiceip/tinyphone/HEAD/config.json
HTTP/2 200
cache-control: max-age=300
content-security-policy: default-src 'none'; style-src 'unsafe-inline'; sandbox
content-type: text/plain; charset=utf-8
etag: "a81debe6a471702516967f016104f157de78c0a244ba0eb0894239e98d30b920"
strict-transport-security: max-age=31536000
x-content-type-options: nosniff
x-frame-options: deny
x-xss-protection: 1; mode=block
x-github-request-id: E8F5:3CE267:1D898E:29C942:67ADBE9A
accept-ranges: bytes
date: Thu, 13 Feb 2025 09:53:53 GMT
via: 1.1 varnish
x-served-by: cache-maa10233-MAA
x-cache: HIT
x-cache-hits: 1
x-timer: S1739440433.061909,VS0,VE1
vary: Authorization,Accept-Encoding,Origin
access-control-allow-origin: *
cross-origin-resource-policy: cross-origin
x-fastly-request-id: b617f3a07c7d8d9fca149c6abd86f6e0e29cbb24
expires: Thu, 13 Feb 2025 09:58:53 GMT
source-age: 280
content-length: 1143
```

Returns `content-type: text/plain; charset=utf-8`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the stability of external configuration retrieval by refining error handling. This update improves overall system resilience when processing external data without altering visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->